### PR TITLE
feat(resend): add email notification integration for tool approvals

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
+    "resend": "^2.0.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",

--- a/src/.env.example
+++ b/src/.env.example
@@ -2,3 +2,6 @@
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 VITE_STORAGE_URL=your_supabase_storage_url
+
+# Resend Email Configuration
+VITE_RESEND_API_KEY=your_resend_api_key

--- a/src/components/admin/ToolSubmissionForm.tsx
+++ b/src/components/admin/ToolSubmissionForm.tsx
@@ -82,6 +82,7 @@ interface ToolSubmissionFormProps {
   toolToEdit?: AITool;
   userId?: string;
   categories?: { id: number; name: string }[];
+  isAdmin?: boolean;
 }
 
 export function ToolSubmissionForm({
@@ -90,6 +91,7 @@ export function ToolSubmissionForm({
   toolToEdit,
   userId,
   categories: propCategories,
+  isAdmin = false,
 }: ToolSubmissionFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedCategories, setSelectedCategories] = useState<string[]>(
@@ -465,26 +467,28 @@ export function ToolSubmissionForm({
             )}
           />
 
-          <FormField
-            control={form.control}
-            name="featured"
-            render={({ field }) => (
-              <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
-                <FormControl>
-                  <Checkbox
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                  />
-                </FormControl>
-                <div className="space-y-1 leading-none">
-                  <FormLabel>Featured Tool</FormLabel>
-                  <p className="text-sm text-muted-foreground">
-                    Featured tools will be highlighted on the homepage
-                  </p>
-                </div>
-              </FormItem>
-            )}
-          />
+          {isAdmin && (
+            <FormField
+              control={form.control}
+              name="featured"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel>Featured Tool</FormLabel>
+                    <p className="text-sm text-muted-foreground">
+                      Featured tools will be highlighted on the homepage
+                    </p>
+                  </div>
+                </FormItem>
+              )}
+            />
+          )}
 
           <FormField
             control={form.control}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -24,7 +24,7 @@ const Footer = () => {
             </p>
             <div className="flex mt-6 space-x-4">
               <a
-                href="https://twitter.com"
+                href="https://x.com/deeplistai"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-muted-foreground hover:text-foreground transition-colors"
@@ -32,7 +32,7 @@ const Footer = () => {
               >
                 <Twitter size={20} />
               </a>
-              <a
+              {/* <a
                 href="https://github.com"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -49,7 +49,7 @@ const Footer = () => {
                 aria-label="LinkedIn"
               >
                 <Linkedin size={20} />
-              </a>
+              </a> */}
             </div>
           </div>
 

--- a/src/integrations/resend/README.md
+++ b/src/integrations/resend/README.md
@@ -1,0 +1,49 @@
+# Email Notifications with Resend
+
+This integration enables email notifications for various events in the AggraFinder portal, such as when an admin approves a tool submission.
+
+## Setup
+
+1. Sign up for a [Resend](https://resend.com) account
+2. Create an API key in the Resend dashboard
+3. Add the API key to your `.env` file:
+   ```
+   VITE_RESEND_API_KEY=your_resend_api_key
+   ```
+4. Install the Resend package:
+   ```bash
+   npm install resend
+   ```
+
+## Usage
+
+The email service is implemented in `client.ts` and provides functions for sending different types of notification emails:
+
+### Tool Approval Notification
+
+Sends an email to a user when their tool submission is approved by an admin:
+
+```typescript
+import { sendToolApprovalEmail } from '@/integrations/resend/client';
+
+// Send notification email
+await sendToolApprovalEmail('user@example.com', 'My Amazing AI Tool');
+```
+
+## Email Templates
+
+Email templates are currently defined inline in the `client.ts` file. For more complex templates, consider moving them to separate HTML files in an `email-templates` directory.
+
+## Adding New Email Types
+
+To add a new type of email notification:
+
+1. Create a new function in `client.ts` following the pattern of existing functions
+2. Design your email template with HTML
+3. Call the function from the appropriate place in your application
+
+## Troubleshooting
+
+- Check the console for error messages if emails aren't being sent
+- Verify your Resend API key is correctly set in the `.env` file
+- Make sure the recipient email address is valid

--- a/src/integrations/resend/client.ts
+++ b/src/integrations/resend/client.ts
@@ -1,0 +1,49 @@
+import { Resend } from 'resend';
+
+// Initialize Resend with API key
+const resendApiKey = import.meta.env.VITE_RESEND_API_KEY;
+const resend = new Resend(resendApiKey);
+
+/**
+ * Send a notification email to a user when their tool submission is approved
+ * @param to Recipient email address
+ * @param toolName Name of the approved tool
+ */
+export const sendToolApprovalEmail = async (
+  to: string,
+  toolName: string
+): Promise<{ success: boolean; error?: string }> => {
+  try {
+    if (!resendApiKey) {
+      console.error('Resend API key is not configured');
+      return { success: false, error: 'Email service not configured' };
+    }
+
+    const { data, error } = await resend.emails.send({
+      from: 'AggraFinder <notifications@aggrafinder.com>',
+      to,
+      subject: `Your Tool "${toolName}" Has Been Approved!`,
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+          <h1 style="color: #4f46e5;">Good News!</h1>
+          <p>Your tool submission <strong>${toolName}</strong> has been approved and is now live on AggraFinder!</p>
+          <p>Your tool is now visible to all users and can be found in our directory.</p>
+          <p>Thank you for contributing to the AggraFinder community!</p>
+          <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #eaeaea;">
+            <p style="font-size: 12px; color: #666;">© ${new Date().getFullYear()} AggraFinder. All rights reserved.</p>
+          </div>
+        </div>
+      `,
+    });
+
+    if (error) {
+      console.error('Error sending approval email:', error);
+      return { success: false, error: error.message };
+    }
+
+    return { success: true };
+  } catch (error: any) {
+    console.error('Error sending approval email:', error);
+    return { success: false, error: error.message || 'Failed to send email' };
+  }
+};

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,12 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = 'https://ozqlpdsmjwrhjyceyskd.supabase.co';
-const SUPABASE_PUBLISHABLE_KEY =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im96cWxwZHNtandyaGp5Y2V5c2tkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDE1Mzc1ODUsImV4cCI6MjA1NzExMzU4NX0.nStPFsaCFMIpXnuyWYjyebGjVMxuYQwU5Ye6Q5RF-SA';
-
-// const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
-// const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 // Fallback values should not be used in production
 if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {


### PR DESCRIPTION
Integrate Resend email service to send notifications when a tool submission is approved. Added Resend package, API key configuration, and email client implementation. Updated AdminDashboard to send approval emails to tool submitters. Also updated .env.example to include Resend API key and modified ToolSubmissionForm to conditionally render admin-only features.