### PR TITLE
feat(pages): add scroll-to-top effect on page load

### DIFF
--- a/src/components/tools/ToolCard.tsx
+++ b/src/components/tools/ToolCard.tsx
@@ -136,6 +136,7 @@ export const ToolCard = ({
           {isImageError ? (
             <div
               className={`absolute inset-0 flex flex-col items-center justify-center ${getGradientForTool()}`}
+              onClick={handleCardClick}
             >
               <ImageOff className="h-10 w-10 mb-2 text-primary/40" />
               <span className="text-xs text-primary/60 font-medium">
@@ -143,19 +144,25 @@ export const ToolCard = ({
               </span>
             </div>
           ) : (
-            <img
-              src={tool.imageUrl}
-              alt={tool.name}
-              className={cn(
-                'absolute top-0 left-0 w-full h-full object-cover transition-all duration-500 transform group-hover:scale-105',
-                isImageLoaded ? 'opacity-100' : 'opacity-0'
-              )}
-              onLoad={() => setIsImageLoaded(true)}
-              onError={handleImageError}
-            />
+            <div onClick={handleCardClick}>
+              <img
+                src={tool.imageUrl}
+                alt={tool.name}
+                className={cn(
+                  'absolute top-0 left-0 w-full h-full object-cover transition-all duration-500 transform group-hover:scale-105',
+                  isImageLoaded ? 'opacity-100' : 'opacity-0'
+                )}
+                onLoad={() => setIsImageLoaded(true)}
+                onError={handleImageError}
+                onClick={handleCardClick}
+              />
+            </div>
           )}
 
-          <div className="absolute inset-0 bg-gradient-to-t from-background/90 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+          <div
+            onClick={handleCardClick}
+            className="absolute inset-0 bg-gradient-to-t from-background/90 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+          ></div>
 
           <div className="absolute top-3 left-3 z-10 flex flex-col gap-1">
             {tool.featured && (
@@ -190,7 +197,8 @@ export const ToolCard = ({
           <div
             className={cn(
               'absolute bottom-3 left-3 z-10 transition-all duration-300',
-              isHovered || isToolSelected(tool.id) ? 'opacity-100' : 'opacity-0'
+              'opacity-100 md:opacity-0 md:group-hover:opacity-100',
+              isToolSelected(tool.id) && 'md:opacity-100'
             )}
           >
             <div className="flex space-x-2">
@@ -201,7 +209,7 @@ export const ToolCard = ({
               />
 
               <AskAIButton
-                isActive={isToolSelected(tool.id)}
+                isActive={showChatModal}
                 onClick={() => setShowChatModal(true)}
                 buttonText="Ask AI"
               />
@@ -299,8 +307,8 @@ export const ToolCard = ({
                   className="inline-flex items-center text-sm font-medium text-primary hover:text-primary/80 transition-colors"
                   onClick={handleLinkClick}
                 >
-                  Visit website
-                  <ExternalLink className="ml-1 h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">Visit website</span>
+                  <ExternalLink className="sm:ml-1 h-3.5 w-3.5" />
                 </a>
               </div>
             </div>
@@ -328,6 +336,7 @@ export const ToolCard = ({
           {isImageError ? (
             <div
               className={`absolute inset-0 flex items-center justify-center ${getGradientForTool()}`}
+              onClick={handleCardClick}
             >
               <ImageOff className="h-6 w-6 text-primary/40" />
             </div>
@@ -337,6 +346,7 @@ export const ToolCard = ({
               alt={tool.name}
               className="absolute top-0 left-0 w-full h-full object-cover transition-all duration-500 transform group-hover:scale-105"
               onError={handleImageError}
+              onClick={handleCardClick}
             />
           )}
         </div>
@@ -382,6 +392,7 @@ export const ToolCard = ({
           {isImageError ? (
             <div
               className={`absolute inset-0 flex flex-col items-center justify-center ${getGradientForTool()}`}
+              onClick={handleCardClick}
             >
               <ImageOff className="h-10 w-10 mb-2 text-primary/40" />
               <span className="text-xs text-primary/60 font-medium">
@@ -398,6 +409,7 @@ export const ToolCard = ({
               )}
               onLoad={() => setIsImageLoaded(true)}
               onError={handleImageError}
+              onClick={handleCardClick}
             />
           )}
 
@@ -512,9 +524,8 @@ export const ToolCard = ({
               <div
                 className={cn(
                   'transition-all duration-300',
-                  isHovered || isToolSelected(tool.id)
-                    ? 'opacity-100'
-                    : 'opacity-0'
+                  'opacity-100 md:opacity-0 md:group-hover:opacity-100',
+                  isToolSelected(tool.id) && 'md:opacity-100'
                 )}
               >
                 <CompareButton
@@ -527,13 +538,12 @@ export const ToolCard = ({
               <div
                 className={cn(
                   'transition-all duration-300',
-                  isHovered || isToolSelected(tool.id)
-                    ? 'opacity-100'
-                    : 'opacity-0'
+                  'opacity-100 md:opacity-0 md:group-hover:opacity-100',
+                  isToolSelected(tool.id) && 'md:opacity-100'
                 )}
               >
                 <AskAIButton
-                  isActive={isToolSelected(tool.id)}
+                  isActive={showChatModal}
                   onClick={() => setShowChatModal(true)}
                   buttonText="Ask AI"
                 />
@@ -547,8 +557,8 @@ export const ToolCard = ({
                 className="inline-flex items-center text-sm font-medium text-primary hover:text-primary/80 transition-colors"
                 onClick={handleLinkClick}
               >
-                Visit website
-                <ExternalLink className="ml-1 h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Visit website</span>
+                <ExternalLink className="sm:ml-1 h-3.5 w-3.5" />
               </a>
             </div>
           </div>

--- a/src/hooks/useSupabaseTools.ts
+++ b/src/hooks/useSupabaseTools.ts
@@ -117,6 +117,7 @@ export const useSupabaseTools = ({
           );
         }
 
+        // Determine which page to fetch
         const pageToFetch = loadMore ? currentPage : page;
         // Apply custom query modifications if provided
         if (typeof customQuery === 'function') {

--- a/src/hooks/useSupabaseToolsByIds.ts
+++ b/src/hooks/useSupabaseToolsByIds.ts
@@ -1,0 +1,107 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { AITool } from '@/types/tools';
+
+interface UseSupabaseToolsByIdsOptions {
+  ids: string[];
+}
+
+export const useSupabaseToolsByIds = ({
+  ids,
+}: UseSupabaseToolsByIdsOptions) => {
+  const [tools, setTools] = useState<AITool[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchToolsByIds = async () => {
+      if (!ids.length) {
+        setTools([]);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+
+        // Fetch only the tools with the specified IDs
+        const { data, error: supabaseError } = await supabase
+          .from('ai_tools')
+          .select('*')
+          .in('id', ids)
+          .eq('approval_status', 'approved');
+
+        if (supabaseError) {
+          throw new Error(supabaseError.message);
+        }
+
+        if (!data) {
+          setTools([]);
+          return;
+        }
+
+        // First, get all the tool IDs to fetch their vote counts
+        const toolIds = data.map((tool) => tool.id);
+
+        // Fetch the vote counts for these tools
+        let voteCountsMap: Record<string, number> = {};
+
+        try {
+          const { data: voteCounts, error: voteCountsError } = await supabase
+            .from('tool_vote_counts')
+            .select('tool_id, upvotes')
+            .in('tool_id', toolIds);
+
+          if (!voteCountsError && voteCounts) {
+            voteCountsMap = voteCounts.reduce((acc, item) => {
+              acc[item.tool_id] = item.upvotes || 0;
+              return acc;
+            }, {} as Record<string, number>);
+          }
+        } catch (err) {
+          console.error('Error fetching vote counts:', err);
+          // Continue without the vote counts if there's an error
+        }
+
+        const transformedData: AITool[] = data.map((item) => ({
+          id: item.id,
+          name: item.name,
+          tagline: item.tagline,
+          description: item.description,
+          imageUrl: item.image_url
+            ? `${import.meta.env.VITE_STORAGE_URL}/${item.image_url}`
+            : '',
+          category: item.category,
+          url: item.url,
+          youtubeUrl: item.youtube_url || '',
+          featured: item.featured,
+          pricing: item.pricing as 'Free' | 'Freemium' | 'Paid' | 'Free Trial',
+          tags: item.tags || [],
+          userId: item.user_id,
+          approvalStatus: item.approval_status as
+            | 'pending'
+            | 'approved'
+            | 'rejected',
+          upvotes: voteCountsMap[item.id] || 0,
+          isAdminAdded: item.is_admin_added || false,
+        }));
+
+        // Preserve the order of tools as specified in the ids array
+        const orderedTools = ids
+          .map((id) => transformedData.find((tool) => tool.id === id))
+          .filter((tool): tool is AITool => tool !== undefined);
+
+        setTools(orderedTools);
+      } catch (err) {
+        console.error('Error fetching tools by IDs:', err);
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchToolsByIds();
+  }, [ids]);
+
+  return { tools, loading, error };
+};

--- a/src/hooks/useToolsCompare.tsx
+++ b/src/hooks/useToolsCompare.tsx
@@ -1,8 +1,7 @@
-
-import React, { createContext, useContext, useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import { useToast } from "@/hooks/use-toast";
-import { AITool } from "@/types/tools";
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useToast } from '@/hooks/use-toast';
+import { AITool } from '@/types/tools';
 
 interface ToolsCompareContextType {
   selectedTools: AITool[];
@@ -14,9 +13,15 @@ interface ToolsCompareContextType {
   removeToolFromComparison: (tool: AITool) => void;
 }
 
-const ToolsCompareContext = createContext<ToolsCompareContextType | undefined>(undefined);
+const ToolsCompareContext = createContext<ToolsCompareContextType | undefined>(
+  undefined
+);
 
-export const ToolsCompareProvider = ({ children }: { children: React.ReactNode }) => {
+export const ToolsCompareProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const MAX_COMPARE_TOOLS = 3;
   const [selectedTools, setSelectedTools] = useState<AITool[]>([]);
   const { toast } = useToast();
@@ -24,71 +29,71 @@ export const ToolsCompareProvider = ({ children }: { children: React.ReactNode }
   const canCompare = selectedTools.length >= 2;
 
   const isToolSelected = (id: string) => {
-    return selectedTools.some(tool => tool.id === id);
+    return selectedTools.some((tool) => tool.id === id);
   };
 
   const toggleToolSelection = (tool: AITool) => {
     if (isToolSelected(tool.id)) {
-      setSelectedTools(prev => prev.filter(t => t.id !== tool.id));
-      toast({
-        title: "Tool removed from comparison",
-        description: `${tool.name} has been removed from comparison.`,
-        variant: "default",
-        duration: 2000, // Short duration to prevent blocking the compare button
-      });
+      setSelectedTools((prev) => prev.filter((t) => t.id !== tool.id));
+      // toast({
+      //   title: 'Tool removed from comparison',
+      //   description: `${tool.name} has been removed from comparison.`,
+      //   variant: 'default',
+      //   duration: 2000, // Short duration to prevent blocking the compare button
+      // });
     } else {
       if (selectedTools.length >= MAX_COMPARE_TOOLS) {
         toast({
-          title: "Maximum tools reached",
+          title: 'Maximum tools reached',
           description: `You can compare up to ${MAX_COMPARE_TOOLS} tools at once.`,
-          variant: "destructive",
+          variant: 'destructive',
           duration: 3000,
         });
         return;
       }
-      
-      setSelectedTools(prev => [...prev, tool]);
-      toast({
-        title: "Tool added to comparison",
-        description: `${tool.name} has been added for comparison.`,
-        variant: "default",
-        duration: 2000, // Short duration to prevent blocking the compare button
-      });
+
+      setSelectedTools((prev) => [...prev, tool]);
+      // toast({
+      //   title: "Tool added to comparison",
+      //   description: `${tool.name} has been added for comparison.`,
+      //   variant: "default",
+      //   duration: 2000, // Short duration to prevent blocking the compare button
+      // });
     }
   };
 
   const removeToolFromComparison = (tool: AITool) => {
-    setSelectedTools(prev => prev.filter(t => t.id !== tool.id));
-    toast({
-      title: "Tool removed",
-      description: `${tool.name} has been removed from comparison.`,
-      variant: "default",
-      duration: 2000,
-    });
+    setSelectedTools((prev) => prev.filter((t) => t.id !== tool.id));
+    // toast({
+    //   title: "Tool removed",
+    //   description: `${tool.name} has been removed from comparison.`,
+    //   variant: "default",
+    //   duration: 2000,
+    // });
   };
 
   const clearSelectedTools = () => {
     setSelectedTools([]);
-    toast({
-      title: "Comparison cleared",
-      description: "All tools have been removed from comparison.",
-      variant: "default",
-      duration: 2000,
-    });
+    // toast({
+    //   title: "Comparison cleared",
+    //   description: "All tools have been removed from comparison.",
+    //   variant: "default",
+    //   duration: 2000,
+    // });
   };
 
   const compareTools = () => {
     if (selectedTools.length < 2) {
       toast({
-        title: "Select at least 2 tools",
-        description: "You need to select at least 2 tools to compare.",
-        variant: "destructive",
+        title: 'Select at least 2 tools',
+        description: 'You need to select at least 2 tools to compare.',
+        variant: 'destructive',
         duration: 3000,
       });
       return;
     }
 
-    const toolIds = selectedTools.map(tool => tool.id).join(',');
+    const toolIds = selectedTools.map((tool) => tool.id).join(',');
     navigate(`/tools/compare/${toolIds}`);
   };
 
@@ -99,14 +104,17 @@ export const ToolsCompareProvider = ({ children }: { children: React.ReactNode }
       try {
         setSelectedTools(JSON.parse(storedTools));
       } catch (e) {
-        console.error("Error parsing stored tools", e);
+        console.error('Error parsing stored tools', e);
         localStorage.removeItem('selectedToolsForCompare');
       }
     }
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('selectedToolsForCompare', JSON.stringify(selectedTools));
+    localStorage.setItem(
+      'selectedToolsForCompare',
+      JSON.stringify(selectedTools)
+    );
   }, [selectedTools]);
 
   return (
@@ -129,7 +137,9 @@ export const ToolsCompareProvider = ({ children }: { children: React.ReactNode }
 export const useToolsCompare = () => {
   const context = useContext(ToolsCompareContext);
   if (context === undefined) {
-    throw new Error("useToolsCompare must be used within a ToolsCompareProvider");
+    throw new Error(
+      'useToolsCompare must be used within a ToolsCompareProvider'
+    );
   }
   return context;
 };

--- a/src/pages/CompareTools.tsx
+++ b/src/pages/CompareTools.tsx
@@ -7,7 +7,7 @@ import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
-import { useSupabaseTools } from '@/hooks/useSupabaseTools';
+import { useSupabaseToolsByIds } from '@/hooks/useSupabaseToolsByIds';
 import { AITool } from '@/types/tools';
 import { cn } from '@/lib/utils';
 
@@ -26,14 +26,15 @@ const CompareTools = () => {
     tools: fetchedTools,
     loading,
     error: fetchError,
-  } = useSupabaseTools();
+  } = useSupabaseToolsByIds({ ids: toolIds });
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   useEffect(() => {
     if (!loading && !fetchError) {
-      const filteredTools = fetchedTools.filter((tool) =>
-        toolIds.includes(tool.id)
-      );
-      setTools(filteredTools);
+      setTools(fetchedTools);
       setIsLoading(false);
     }
 
@@ -41,7 +42,7 @@ const CompareTools = () => {
       setError(fetchError);
       setIsLoading(false);
     }
-  }, [loading, fetchError, fetchedTools, toolIds]);
+  }, [loading, fetchError, fetchedTools]);
 
   const handleImageLoaded = (id: string) => {
     setIsImageLoadedMap((prev) => ({ ...prev, [id]: true }));

--- a/src/pages/CookiesPolicy.tsx
+++ b/src/pages/CookiesPolicy.tsx
@@ -2,8 +2,13 @@ import { Helmet } from 'react-helmet';
 import { Container } from '@/components/ui/container';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
+import { useEffect } from 'react';
 
 const CookiesPolicy = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <>
       <Helmet>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,8 +11,13 @@ import PostToolCTA from '@/components/home/PostToolCTA';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
 import { MessageCircle } from 'lucide-react';
+import { useEffect } from 'react';
 
 const Index = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <>
       <Helmet>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -2,8 +2,13 @@ import { Helmet } from 'react-helmet';
 import { Container } from '@/components/ui/container';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
+import { useEffect } from 'react';
 
 const PrivacyPolicy = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <>
       <Helmet>

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -5,7 +5,7 @@ import Footer from '@/components/layout/Footer';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 
@@ -16,6 +16,10 @@ const Support = () => {
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -2,8 +2,13 @@ import { Helmet } from 'react-helmet';
 import { Container } from '@/components/ui/container';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
+import { useEffect } from 'react';
 
 const TermsOfService = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <>
       <Helmet>


### PR DESCRIPTION
refactor(CompareTools): replace useSupabaseTools with useSupabaseToolsByIds for filtering style(useToolsCompare): improve code formatting and remove redundant toast notifications chore(useSupabaseTools): add comment for clarity on page fetching logic
```

This commit message summarizes the key changes:
1. Added a `useEffect` to scroll to the top on page load across multiple pages.
2. Refactored `CompareTools` to use `useSupabaseToolsByIds` for more efficient filtering.
3. Improved code formatting in `useToolsCompare` and removed unnecessary toast notifications.
4. Added a clarifying comment in `useSupabaseTools` for better code understanding.