### PR TITLE
fix(mobile): hide prompt after install click

### DIFF
--- a/src/components/mobile/AddToHomeScreen.tsx
+++ b/src/components/mobile/AddToHomeScreen.tsx
@@ -52,6 +52,7 @@ const AddToHomeScreen: React.FC = () => {
   };
 
   const handleInstallClick = () => {
+    setIsVisible(false);
     localStorage.setItem('add_to_home_prompt_interacted', 'installed');
     trackEvent('user_engagement', 'add_to_home_prompt_accepted', {
       browser_type: browser,


### PR DESCRIPTION
Ensure the add-to-home prompt is hidden immediately after the user clicks the install button to prevent further interactions with the dismissed prompt.