### PR TITLE
feat: add site URL utility and update redirect logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 VITE_SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
 VITE_STORAGE_URL=your_storage_url_here
 VITE_ANTHROPIC_API_KEY=your_entropic_api_key_here
+
+# Site URL (used instead of window.location.origin)
+VITE_SITE_URL=https://yourdomain.com

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSupabaseAdmin } from '@/hooks/useSupabaseAdmin';
+import { getSiteUrl } from '@/utils/siteUrl';
 import { supabase } from '@/integrations/supabase/client';
 import { AITool } from '@/types/tools';
 import { AIOucome } from '@/types/outcomes';
@@ -580,7 +581,7 @@ export function AdminDashboard({ userId }: AdminDashboardProps) {
             .single();
 
           if (!userFetchError && userData?.email) {
-            const baseUrl = window.location.origin;
+            const baseUrl = getSiteUrl();
             const toolDetailsUrl = `${baseUrl}/tools/${id}`;
 
             // Generate the HTML content using our template

--- a/src/components/tools/ToolCardChat.tsx
+++ b/src/components/tools/ToolCardChat.tsx
@@ -5,6 +5,7 @@ import { Send, X, MessageSquare, Loader2 } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
 import { AITool } from '@/types/tools';
 import { useAIChatAnalytics } from '@/hooks/useAIChatAnalytics';
+import { getSiteUrl } from '@/utils/siteUrl';
 
 type Message = {
   id: string;
@@ -82,7 +83,7 @@ const ToolCardChat = ({ tool, onClose }: ToolCardChatProps) => {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${apiKey}`,
-            'HTTP-Referer': window.location.origin,
+            'HTTP-Referer': getSiteUrl(),
           },
           body: JSON.stringify({
             model: 'qwen/qwen3-0.6b-04-28:free', // Using a free model for this feature

--- a/src/components/user/GoogleLoginButton.tsx
+++ b/src/components/user/GoogleLoginButton.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Loader2 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { getSiteUrl } from '@/utils/siteUrl';
 
 interface GoogleLoginButtonProps {
   className?: string;
@@ -17,7 +18,7 @@ const GoogleLoginButton = ({ className = '' }: GoogleLoginButtonProps) => {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${window.location.origin}/dashboard`,
+          redirectTo: `${getSiteUrl()}/dashboard`,
         },
       });
 

--- a/src/hooks/useSupabaseTools.ts
+++ b/src/hooks/useSupabaseTools.ts
@@ -13,7 +13,7 @@ interface UseSupabaseToolsOptions {
   excludeId?: string; // Add this to exclude specific tools (useful for related tools)
   userId?: string; // Add this to filter by user ID
   includeUnapproved?: boolean; // Add this to include unapproved tools (for admin views)
-  sortBy?: 'created_at' | 'popularity';
+  sortBy?: 'created_at' | 'popularity' | 'random';
   customQuery?: (query: any) => any; // Allow custom query modifications
 }
 
@@ -132,6 +132,11 @@ export const useSupabaseTools = ({
           query = query.order('name', { ascending: true });
         } else if (sortBy === 'created_at') {
           query = query.order('created_at', { ascending: false });
+        } else if (sortBy === 'random') {
+          // No need to apply additional ordering as we're using ai_tools_random view
+          // which already has randomized ordering
+        } else {
+          // Default case - no specific sorting applied, will use the random order from view
         }
 
         query = query.range(

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
+import { getSiteUrl } from '@/utils/siteUrl';
 import { supabase } from '@/integrations/supabase/client';
 import GoogleLoginButton from '@/components/user/GoogleLoginButton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -95,7 +96,7 @@ const Auth = () => {
     setLoading(true);
     try {
       const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
-        redirectTo: `${window.location.origin}/update-password`,
+        redirectTo: `${getSiteUrl()}/update-password`,
       });
       if (error) throw error;
       toast.success('Password reset email sent! Please check your inbox.');

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -231,10 +231,10 @@ const Support = () => {
                     How do I submit an AI tool to the directory?
                   </h3>
                   <p className="text-muted-foreground">
-                    You can submit a new AI tool by going to the "Request Tool"
-                    page and filling out the submission form. Our team will
-                    review your submission and add it to our directory if it
-                    meets our criteria.
+                    To submit an AI tool, you need to log in to your account and
+                    access the submission form from your dashboard. Our team
+                    will review your submission and make it live if it meets our
+                    criteria.
                   </p>
                 </div>
 
@@ -243,21 +243,21 @@ const Support = () => {
                     How can I update information about my AI tool?
                   </h3>
                   <p className="text-muted-foreground">
-                    If you need to update information about your AI tool, please
-                    contact us through this support page with the details of the
-                    changes needed.
+                    You can update your tool information anytime, even after
+                    submission. Simply log in to your account, navigate to your
+                    dashboard, and edit the details of your submitted tool.
                   </p>
                 </div>
 
                 <div>
                   <h3 className="text-lg font-medium mb-2">
-                    How are tools ranked in the directory?
+                    How long does the review process take?
                   </h3>
                   <p className="text-muted-foreground">
-                    Tools are ranked based on a combination of factors including
-                    user ratings, number of reviews, and overall popularity. We
-                    regularly update our ranking algorithm to ensure the most
-                    relevant tools appear first.
+                    We typically review submissions within 2-3 business days.
+                    Once approved, your tool will be immediately published to
+                    our directory. You'll receive a notification when your
+                    submission is approved.
                   </p>
                 </div>
 

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -53,7 +53,9 @@ const Tools = () => {
     return storedView || 'grid'; // Default to grid if no preference is stored
   });
 
-  const [sortOption, setSortOption] = useState<'newest' | 'popular'>('newest');
+  const [sortOption, setSortOption] = useState<'newest' | 'popular' | 'random'>(
+    'random'
+  );
   const [showFavorites, setShowFavorites] = useState(false);
   const [selectedFeaturedTool, setSelectedFeaturedTool] = useState<any | null>(
     null
@@ -105,7 +107,9 @@ const Tools = () => {
         ? 'popularity'
         : sortOption === 'newest'
         ? 'created_at'
-        : '',
+        : sortOption === 'random'
+        ? 'random'
+        : 'random', // Default to random sorting
   });
 
   // Removed infinite scroll observer in favor of a 'See More' button approach
@@ -390,7 +394,7 @@ const Tools = () => {
                             setSelectedPricing('All');
                             setSearchTerm('');
                             setShowFavorites(false);
-                            setSortOption('newest');
+                            setSortOption('random');
                             setView('grid'); // Changed from 'list' to 'grid' to maintain grid as default
                             // Reset URL to clean state
                             navigate('/tools', { replace: true });
@@ -449,7 +453,17 @@ const Tools = () => {
                           <ArrowUpDown className="h-4 w-4 mr-2 text-muted-foreground" />
                           Sort by
                         </h3>
-                        <div className="flex space-x-2 w-full">
+                        <div className="flex flex-wrap gap-2 w-full">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className={`px-3 flex-1 ${
+                              sortOption === 'random' ? 'bg-secondary/70' : ''
+                            }`}
+                            onClick={() => setSortOption('random')}
+                          >
+                            Random
+                          </Button>
                           <Button
                             variant="ghost"
                             size="sm"

--- a/src/utils/seo.tsx
+++ b/src/utils/seo.tsx
@@ -1,5 +1,6 @@
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
+import { getSiteUrl } from './siteUrl';
 
 interface SEOProps {
   title?: string;
@@ -29,7 +30,7 @@ export const SEO = ({
   children,
 }: SEOProps) => {
   const { pathname } = useLocation();
-  const siteUrl = window.location.origin;
+  const siteUrl = getSiteUrl();
   const fullUrl = `${siteUrl}${pathname}`;
   const ogImageUrl = image.startsWith('http') ? image : `${siteUrl}${image}`;
 
@@ -106,12 +107,12 @@ export const generateHomeStructuredData = (featuredTools: any[] = []) => {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name: 'DeepListAI',
-    url: window.location.origin,
+    url: getSiteUrl(),
     description:
       'Discover the most powerful and innovative AI tools to enhance your productivity, creativity, and workflow.',
     potentialAction: {
       '@type': 'SearchAction',
-      target: `${window.location.origin}/tools?search={search_term_string}`,
+      target: `${getSiteUrl()}/tools?search={search_term_string}`,
       'query-input': 'required name=search_term_string',
     },
   };
@@ -127,6 +128,6 @@ export const generateToolsCollectionStructuredData = () => {
     name: 'AI Tools Collection',
     description:
       'Browse our comprehensive collection of AI tools for various use cases and industries.',
-    url: `${window.location.origin}/tools`,
+    url: `${getSiteUrl()}/tools`,
   };
 };

--- a/src/utils/siteUrl.ts
+++ b/src/utils/siteUrl.ts
@@ -1,0 +1,7 @@
+/**
+ * Utility function to get the site URL from environment variables
+ * with a fallback to window.location.origin
+ */
+export const getSiteUrl = (): string => {
+  return import.meta.env.VITE_SITE_URL || window.location.origin;
+};


### PR DESCRIPTION
Introduce a utility function `getSiteUrl` to centralize site URL retrieval from environment variables or fallback to `window.location.origin`. Update all redirect and URL-related logic across components to use this utility for consistency and flexibility. Also, add `random` sorting option to tools page and update support page FAQ content.