### PR TITLE
feat(tools): add tool badge for approved tools

### DIFF
--- a/public/badge.svg
+++ b/public/badge.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20" viewBox="0 0 160 20">
+  <rect width="160" height="20" rx="10" fill="#f3f4f6"/>
+  <text x="10" y="14" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#111827">Find me on</text>
+  <text x="70" y="14" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="bold" fill="#6366f1">DeepList AI</text>
+</svg>

--- a/src/components/tools/ToolBadge.tsx
+++ b/src/components/tools/ToolBadge.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Copy, Check, Code2, Star } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface ToolBadgeProps {
+  toolId: string;
+  toolName: string;
+}
+
+export const ToolBadge = ({ toolId, toolName }: ToolBadgeProps) => {
+  const [copied, setCopied] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  // Use the VITE_SITE_URL environment variable if available, otherwise fallback to window.location.origin
+  const baseUrl = import.meta.env.VITE_SITE_URL || window.location.origin;
+  const toolUrl = `${baseUrl}/tools/${toolId}?utm_source=badge&utm_medium=referral&utm_campaign=tool_badge&utm_content=${encodeURIComponent(
+    toolName
+  )}`;
+
+  const badgeHtml = `<a href="${toolUrl}" target="_blank" rel="noopener noreferrer" style="display:inline-block;margin-right:8px;text-decoration:none;border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);max-width:300px;font-family:system-ui,-apple-system,sans-serif"><div style="display:flex;align-items:center;padding:10px;background:white"><div style="width:36px;height:36px;border-radius:6px;display:flex;align-items:center;justify-content:center;margin-right:10px"><img src="${baseUrl}/images/web-logo.png" alt="Logo" style="width:30px;height:30px;object-fit:contain" /></div><div style="flex:1"><div style="font-size:12px;font-weight:500;color:#4b5563">LISTED ON</div><div style="font-size:16px;font-weight:700;color:#111827">DeepList AI</div></div><div style="color:#2563eb;margin-left:13px">★</div></div></a>`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(badgeHtml);
+    setCopied(true);
+    toast.success('Badge code copied to clipboard');
+
+    // Reset the copied state after 2 seconds
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        className="flex items-center gap-2 font-medium hover:bg-muted/80 transition-colors"
+        onClick={() => setOpen(true)}
+        title="Add this badge to your website"
+      >
+        <Code2 className="h-4 w-4" />
+        Tool Badge
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Add Tool Badge to Your Website</DialogTitle>
+            <DialogDescription>
+              Show visitors your tool is listed on DeepList AI
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col space-y-4">
+            <div className="rounded-lg border overflow-hidden">
+              <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/30 p-6 flex flex-col items-center justify-center">
+                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border p-4 max-w-xs mx-auto">
+                  <div className="flex items-center gap-3">
+                    <div className="text-white rounded-lg w-10 h-10 flex items-center justify-center">
+                      <img
+                        src="/images/web-logo.png"
+                        alt="Logo"
+                        className="w-15 h-15 object-contain"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <div className="text-sm font-medium text-gray-600">
+                        LISTED ON
+                      </div>
+                      <div className="text-lg font-bold">DeepList AI</div>
+                    </div>
+                    <Star className="h-6 w-6 text-blue-600 fill-current ml-3" />
+                  </div>
+                </div>
+                <div className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
+                  Badge Preview
+                </div>
+              </div>
+
+              <div className="p-4 bg-gray-50 dark:bg-gray-900/50 border-t">
+                <Button
+                  className="w-full bg-blue-600 hover:bg-blue-700 text-white"
+                  variant="default"
+                  onClick={() => handleCopy()}
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-4 w-4 mr-2" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-4 w-4 mr-2" />
+                      Copy Badge Code
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Tabs = TabsPrimitive.Root
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -12,13 +12,13 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
       className
     )}
     {...props}
   />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
@@ -27,13 +27,13 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className
     )}
     {...props}
   />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -42,12 +42,12 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       className
     )}
     {...props}
   />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/components/user/MyToolsManager.tsx
+++ b/src/components/user/MyToolsManager.tsx
@@ -20,6 +20,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react';
+import { ToolBadge } from '@/components/tools/ToolBadge';
 import { ToolSubmissionForm } from '@/components/admin/ToolSubmissionForm';
 import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
@@ -280,6 +281,19 @@ export const MyToolsManager = ({ userId }: MyToolsManagerProps) => {
                         {tool.pricing}
                       </Badge>
                     </div>
+                    {tool.approvalStatus === 'approved' && (
+                      <div className="mt-3 border-t pt-3">
+                        <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+                          <div className="flex-shrink-0">
+                            <ToolBadge toolId={tool.id} toolName={tool.name} />
+                          </div>
+                          <span className="text-xs text-muted-foreground">
+                            Add this badge to show your tool is LISTED ON
+                            DeepList AI
+                          </span>
+                        </div>
+                      </div>
+                    )}
                   </div>
                   <div className="flex flex-col gap-2">
                     <Button

--- a/src/templates/ToolApprovalEmail.tsx
+++ b/src/templates/ToolApprovalEmail.tsx
@@ -123,6 +123,20 @@ export const ToolApprovalEmailTemplate = ({
           <a href="${toolUrl}" class="button">View Your Tool</a>
         </div>
 
+      <div class="info-box">
+        <p style="margin-bottom: 10px;"><strong>Write the First Comment:</strong></p>
+        <p class="help-text">
+          Got a tip or something cool to share about this tool? Start things off by leaving the first comment to help others learn more about it.
+        </p>
+      </div>
+
+      <div class="info-box">
+        <p style="margin-bottom: 10px;"><strong>Tool Badge Available:</strong></p>
+        <p class="help-text">
+          A badge is now available on your dashboard. Adding it to your website lets visitors know your tool is listed on DeepList AI.
+        </p>
+      </div>
+
         
         <p>
           If the button above doesn't work, copy and paste the following link


### PR DESCRIPTION
Introduce a new tool badge component for approved tools, allowing users to showcase their tools on their websites. The badge includes a preview and copy-to-clipboard functionality. Additionally, update the email template and MyToolsManager to inform users about the badge availability.