### PR TITLE
style(QuickToolChat): adjust button position to center vertically

### DIFF
--- a/src/components/quick-tools/QuickToolChat.tsx
+++ b/src/components/quick-tools/QuickToolChat.tsx
@@ -1119,7 +1119,7 @@ export const QuickToolChat = ({
             />
             <motion.div
               whileTap={{ scale: 0.95 }}
-              className="absolute right-2 top-1 -translate-y-1/2"
+              className="absolute right-2 top-1/4 -translate-y-1/2"
             >
               <Button
                 size="icon"


### PR DESCRIPTION
The button was slightly misaligned vertically. Changed top positioning from 'top-1' to 'top-1/4' to better center it within its container.