### PR TITLE
style(QuickToolChat): adjust input area bottom spacing for better vis…

### DIFF
--- a/src/components/quick-tools/QuickToolChat.tsx
+++ b/src/components/quick-tools/QuickToolChat.tsx
@@ -1029,7 +1029,7 @@ export const QuickToolChat = ({
       {/* Input Area with Modern Card Styling */}
       <div
         data-input-area
-        className="p-4 border border-primary/60 rounded-2xl bg-background/95 shadow-md mx-0 sm:mx-4 backdrop-blur-sm fixed bottom-2 left-2 right-2 sm:sticky sm:bottom-10 z-10 hover:border-primary/40 transition-all duration-300 hover:shadow-lg"
+        className="p-4 border border-primary/60 rounded-2xl bg-background/95 shadow-md mx-0 sm:mx-4 backdrop-blur-sm fixed bottom-4 left-2 right-2 sm:sticky sm:bottom-10 z-10 hover:border-primary/40 transition-all duration-300 hover:shadow-lg"
       >
         <div className="flex items-center gap-3 w-full">
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
…ibility

The bottom spacing of the input area was increased from 2 to 4 units to improve visibility and prevent content from appearing too close to the screen edge on mobile devices