### PR TITLE
fix: update navigation paths to root from /tools

### DIFF
--- a/src/pages/CompareTools.tsx
+++ b/src/pages/CompareTools.tsx
@@ -117,7 +117,7 @@ const CompareTools = () => {
               className="mb-6 group transition-all duration-300 hover:translate-x-[-5px]"
               asChild
             >
-              <Link to="/tools">
+              <Link to="/">
                 <ArrowLeft className="h-4 w-4 mr-2 transition-transform group-hover:scale-110" />
                 Back to tools
               </Link>

--- a/src/pages/QuickToolDetails.tsx
+++ b/src/pages/QuickToolDetails.tsx
@@ -166,7 +166,7 @@ const QuickToolDetails = () => {
     if (location.key !== 'default') {
       navigate(-1);
     } else {
-      navigate('/tools?type=quick');
+      navigate('/?type=quick');
     }
   };
 

--- a/src/pages/ToolDetails.tsx
+++ b/src/pages/ToolDetails.tsx
@@ -131,7 +131,7 @@ const ToolDetails = () => {
     if (location.key !== 'default') {
       navigate(-1);
     } else {
-      navigate('/tools');
+      navigate('/');
     }
   };
 


### PR DESCRIPTION
Change navigation paths from '/tools' to '/' in ToolDetails, QuickToolDetails, and CompareTools components to improve routing consistency and simplify the navigation structure