### PR TITLE
refactor(QuickToolForm): add comment for typing animation initialization

### DIFF
--- a/src/components/quick-tools/QuickToolForm.tsx
+++ b/src/components/quick-tools/QuickToolForm.tsx
@@ -689,6 +689,7 @@ Do not include any text outside of this JSON array.`;
       setTypingIndicator(false);
       setMessages((prev) => [...prev, assistantMessage]);
 
+      // Start the typing animation
       animateTyping(assistantMessage.id, assistantMessage.content);
     } catch (error) {
       console.error('Error sending message:', error);


### PR DESCRIPTION
The comment clarifies the purpose of the animateTyping call, making the code's intent more explicit to maintainers