### PR TITLE
refactor(QuickToolForm): remove redundant comment for typing animation

### DIFF
--- a/src/components/quick-tools/QuickToolForm.tsx
+++ b/src/components/quick-tools/QuickToolForm.tsx
@@ -689,7 +689,6 @@ Do not include any text outside of this JSON array.`;
       setTypingIndicator(false);
       setMessages((prev) => [...prev, assistantMessage]);
 
-      // Start the typing animation
       animateTyping(assistantMessage.id, assistantMessage.content);
     } catch (error) {
       console.error('Error sending message:', error);


### PR DESCRIPTION
The comment was unnecessary as the animateTyping function name is self-explanatory